### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,6 @@
+name        := "mbedtls"
+description := "A portable, flexible SSL library."
+gitrepo     := "https://github.com/ARMmbed/mbedtls.git"
+homepage    := "https://github.com/ARMmbed/mbedtls/"
+license     := "Apache-2.0"
+version     := 2.18.1 sha256:adc9055a494533df3a5b4e26b3c2868fc506f1d5c4f70f377f6ee3967d4ad624 https://github.com/ARMmbed/mbedtls/archive/mbedtls-2.18.1.tar.gz


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

